### PR TITLE
Add Windows/MSYS2 support

### DIFF
--- a/MSYS2_SETUP.md
+++ b/MSYS2_SETUP.md
@@ -1,0 +1,206 @@
+# Building SourceMinder on Windows (MSYS2)
+
+This guide explains how to build SourceMinder on Windows using MSYS2, which provides a Unix-like environment with the necessary tools and libraries.
+
+## Quick Start (Python indexer only)
+
+If you just need the Python indexer, follow these minimal steps:
+
+```bash
+# In MSYS2 UCRT64 terminal:
+pacman -S --needed mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-sqlite3 mingw-w64-ucrt-x86_64-tree-sitter mingw-w64-ucrt-x86_64-libsystre git make
+
+cd /c/Projects/SourceMinder  # adjust path as needed
+
+# Clone tree-sitter for headers (MSYS2 package doesn't include dev headers)
+git clone --depth 1 https://github.com/tree-sitter/tree-sitter.git
+
+# Clone the Python grammar
+git clone https://github.com/tree-sitter/tree-sitter-python.git
+
+./configure --enable-python
+make
+```
+
+## Full Installation
+
+### 1. Install MSYS2
+
+Download and install MSYS2 from: https://www.msys2.org/
+
+Run the installer and follow the prompts. Default installation path is `C:\msys64`.
+
+### 2. Update MSYS2
+
+Open "MSYS2 UCRT64" from the Start menu (important: use UCRT64, not MSYS or MINGW32).
+
+Update the package database:
+```bash
+pacman -Syu
+```
+
+If prompted to close the terminal, do so and reopen "MSYS2 UCRT64", then run:
+```bash
+pacman -Su
+```
+
+### 3. Install Required Packages
+
+```bash
+pacman -S --needed \
+    mingw-w64-ucrt-x86_64-gcc \
+    mingw-w64-ucrt-x86_64-sqlite3 \
+    mingw-w64-ucrt-x86_64-tree-sitter \
+    mingw-w64-ucrt-x86_64-libsystre \
+    git \
+    make
+```
+
+## Building SourceMinder
+
+### 1. Navigate to the Repository
+
+In the MSYS2 UCRT64 terminal:
+```bash
+cd /c/Projects/SourceMinder  # adjust to your path
+```
+
+Note: In MSYS2, Windows paths use forward slashes and `C:` becomes `/c/`.
+
+### 2. Clone Tree-Sitter and Grammars
+
+First, clone the main tree-sitter repository for headers (the MSYS2 package only includes the runtime library, not development headers):
+
+```bash
+git clone --depth 1 https://github.com/tree-sitter/tree-sitter.git
+```
+
+Then clone the grammars you need:
+
+```bash
+# For Python only:
+git clone https://github.com/tree-sitter/tree-sitter-python.git
+
+# Or for all languages:
+git clone https://github.com/tree-sitter/tree-sitter-c.git
+git clone https://github.com/tree-sitter/tree-sitter-go.git
+git clone https://github.com/tree-sitter/tree-sitter-php.git
+git clone https://github.com/tree-sitter/tree-sitter-python.git
+git clone https://github.com/tree-sitter/tree-sitter-typescript.git
+```
+
+### 3. Configure
+
+```bash
+# Python only (fastest build):
+./configure --enable-python
+
+# Or all languages:
+./configure --enable-all
+
+# Or specific combinations:
+./configure --enable-python --enable-c
+```
+
+### 4. Build
+
+```bash
+make
+```
+
+The binaries will be created in the `build/` directory with symlinks in the project root.
+
+## Usage
+
+### Running from MSYS2 Terminal
+
+```bash
+# Index a directory
+./index-c . --once --verbose
+
+# Query the index
+./qi test --limit 10
+```
+
+### Running from Windows Command Prompt or PowerShell
+
+Add the MSYS2 bin directory to your PATH, or use full paths:
+
+```cmd
+C:\msys64\ucrt64\bin\bash.exe -c "cd /c/Projects/SourceMinder && ./qi test --limit 10"
+```
+
+Or copy the required DLLs alongside the executables for standalone use (see "Standalone Executables" below).
+
+## Standalone Executables (Optional)
+
+To run the executables outside of MSYS2, copy the required DLLs:
+
+```bash
+# From MSYS2 UCRT64 terminal
+cp /ucrt64/bin/libsqlite3-0.dll build/
+cp /ucrt64/bin/libtree-sitter.dll build/
+cp /ucrt64/bin/libgcc_s_seh-1.dll build/
+cp /ucrt64/bin/libwinpthread-1.dll build/
+```
+
+Then you can run from Windows Command Prompt:
+```cmd
+cd C:\Projects\SourceMinder\build
+qi.exe test --limit 10
+```
+
+## Daemon Mode Note
+
+The file watcher (daemon mode) uses Windows-specific APIs when built under MSYS2. If you encounter issues with `--daemon` mode, use `--once` mode instead:
+
+```bash
+# Instead of daemon mode:
+./index-c . --once --verbose
+
+# Re-run manually when files change, or use a watch script
+```
+
+## Troubleshooting
+
+### "command not found: make"
+Ensure you're using "MSYS2 UCRT64" terminal, not plain "MSYS2".
+
+### "sqlite3.h: No such file"
+Install the SQLite development package:
+```bash
+pacman -S mingw-w64-ucrt-x86_64-sqlite3
+```
+
+### "tree_sitter/api.h: No such file" or "cannot find -ltree-sitter"
+The MSYS2 tree-sitter package only includes the CLI tool, not the library or headers. Clone the main tree-sitter repository:
+```bash
+git clone --depth 1 https://github.com/tree-sitter/tree-sitter.git
+```
+The configure script will find headers in `tree-sitter/lib/include/` and build the library from `tree-sitter/lib/src/lib.c`.
+
+### "regex.h: No such file or directory"
+Install the libsystre package which provides POSIX regex:
+```bash
+pacman -S mingw-w64-ucrt-x86_64-libsystre
+```
+
+### Linker errors about undefined references
+Make sure you're using the UCRT64 environment consistently. Don't mix MSYS, MINGW32, MINGW64, and UCRT64.
+
+### Path issues with backslashes
+SourceMinder expects Unix-style paths (forward slashes). In MSYS2, Windows paths are automatically converted:
+- `C:\Projects\SourceMinder` becomes `/c/Projects/SourceMinder`
+
+## Environment Comparison
+
+| Environment | Use Case |
+|-------------|----------|
+| MSYS2 UCRT64 | **Recommended** - Modern Windows C runtime |
+| MSYS2 MINGW64 | Alternative - Older MinGW runtime |
+| MSYS2 MSYS | Unix tools only - Don't use for building |
+
+## See Also
+
+- [README.md](README.md) - Main documentation
+- [MACOS_SETUP.md](MACOS_SETUP.md) - macOS build instructions

--- a/c/c_language.c
+++ b/c/c_language.c
@@ -2044,7 +2044,7 @@ int parser_init(CParser *parser, SymbolFilter *filter) {
 }
 
 int parser_parse_file(CParser *parser, const char *filepath, const char *project_root, ParseResult *result) {
-    FILE *fp = safe_fopen(filepath, "r", 0);
+    FILE *fp = safe_fopen(filepath, "rb", 0);  /* binary mode for accurate byte count */
     if (!fp) {
         fprintf(stderr, "Cannot open file: %s\n", filepath);
         return -1;

--- a/configure
+++ b/configure
@@ -11,13 +11,23 @@ CC="${CC:-gcc}"
 
 # Detect OS for platform-specific commands
 UNAME_S=$(uname -s)
-if [ "$UNAME_S" = "Darwin" ]; then
-    # macOS requires empty string after -i
-    SED_INPLACE="sed -i ''"
-else
-    # Linux uses -i directly
-    SED_INPLACE="sed -i"
-fi
+IS_MSYS=0
+
+# Check for MSYS2/MinGW environment
+case "$UNAME_S" in
+    MINGW*|MSYS*)
+        IS_MSYS=1
+        SED_INPLACE="sed -i"
+        ;;
+    Darwin)
+        # macOS requires empty string after -i
+        SED_INPLACE="sed -i ''"
+        ;;
+    *)
+        # Linux uses -i directly
+        SED_INPLACE="sed -i"
+        ;;
+esac
 
 # Parse command line arguments
 show_help() {
@@ -285,17 +295,35 @@ PHP_GRAMMAR_DIR = tree-sitter-php/php
 GO_GRAMMAR_DIR = tree-sitter-go
 PYTHON_GRAMMAR_DIR = tree-sitter-python
 
-# macOS (Homebrew) paths
-ifeq ($(UNAME_S),Darwin)
+# Detect MSYS2/MinGW environment
+IS_MSYS := $(findstring MINGW,$(UNAME_S))$(findstring MSYS,$(UNAME_S))
+
+ifneq ($(IS_MSYS),)
+    # MSYS2/MinGW paths (Windows)
+    # Detect MSYS2 prefix (UCRT64 vs MINGW64)
+    MSYS2_PREFIX := $(shell test -d /ucrt64 && echo /ucrt64 || echo /mingw64)
+    # Include tree-sitter/lib/include for api.h (clone tree-sitter repo if needed)
+    # Also include tree-sitter/lib/src for internal headers needed by lib.c
+    INCLUDE_PATHS = -I$(MSYS2_PREFIX)/include -Itree-sitter/lib/include -Itree-sitter/lib/src -I. -I$(TS_GRAMMAR_DIR)/src -I$(C_GRAMMAR_DIR)/src -I$(PHP_GRAMMAR_DIR)/src -I$(GO_GRAMMAR_DIR)/src -I$(PYTHON_GRAMMAR_DIR)/src
+    LIB_PATHS = -L$(MSYS2_PREFIX)/lib
+    # Executable extension for Windows
+    EXE_EXT = .exe
+    # Build tree-sitter from source (MSYS2 package doesn't include the library)
+    TREE_SITTER_SRC = tree-sitter/lib/src/lib.c
+    TREE_SITTER_OBJ = tree-sitter/lib/src/lib.o
+else ifeq ($(UNAME_S),Darwin)
+    # macOS (Homebrew) paths
     # Try to detect Homebrew prefix (Apple Silicon vs Intel)
     HOMEBREW_PREFIX := $(shell test -d /opt/homebrew && echo /opt/homebrew || echo /usr/local)
     SQLITE_PREFIX := $(HOMEBREW_PREFIX)/opt/sqlite
     INCLUDE_PATHS = -I$(HOMEBREW_PREFIX)/include -I$(SQLITE_PREFIX)/include -I. -I$(TS_GRAMMAR_DIR)/src -I$(C_GRAMMAR_DIR)/src -I$(PHP_GRAMMAR_DIR)/src -I$(GO_GRAMMAR_DIR)/src -I$(PYTHON_GRAMMAR_DIR)/src
     LIB_PATHS = -L$(HOMEBREW_PREFIX)/lib -L$(SQLITE_PREFIX)/lib
+    EXE_EXT =
 else
     # Linux paths
     INCLUDE_PATHS = -I/usr/local/include -I/usr/include -I. -I$(TS_GRAMMAR_DIR)/src -I$(C_GRAMMAR_DIR)/src -I$(PHP_GRAMMAR_DIR)/src -I$(GO_GRAMMAR_DIR)/src -I$(PYTHON_GRAMMAR_DIR)/src
     LIB_PATHS = -L/usr/local/lib -Wl,-rpath,/usr/local/lib
+    EXE_EXT =
 endif
 
 # Base flags for release and debug
@@ -305,8 +333,15 @@ BASE_CFLAGS_DEBUG = -g -O0 -std=c11 -D_POSIX_C_SOURCE=200809L -D_DEFAULT_SOURCE 
 # Default to release build
 BASE_CFLAGS = $(BASE_CFLAGS_RELEASE)
 
-LDFLAGS = $(LIB_PATHS) -lsqlite3 -ltree-sitter
-LDFLAGS_DEBUG = $(LIB_PATHS) -lsqlite3 -ltree-sitter -rdynamic
+# Linker flags - platform specific
+ifneq ($(IS_MSYS),)
+    # Windows: tree-sitter built from source, libsystre provides POSIX regex
+    LDFLAGS = $(LIB_PATHS) -lsqlite3 -lsystre
+    LDFLAGS_DEBUG = $(LIB_PATHS) -lsqlite3 -lsystre
+else
+    LDFLAGS = $(LIB_PATHS) -lsqlite3 -ltree-sitter
+    LDFLAGS_DEBUG = $(LIB_PATHS) -lsqlite3 -ltree-sitter -rdynamic
+endif
 
 # Compiler-specific warning flags for our code (strict)
 GCC_WARNINGS = -Wall -Wextra -fprefetch-loop-arrays
@@ -335,6 +370,13 @@ endif
 # Shared source files
 SHARED_SRC = shared/database.c shared/filter.c shared/file_walker.c shared/file_watcher.c shared/validation.c shared/comment_utils.c shared/string_utils.c shared/file_opener.c shared/indexer_main.c shared/extensions.c shared/parse_result.c shared/file_utils.c shared/paths.c shared/toc.c shared/debug.c shared/version.c shared/sql_builder.c
 SHARED_OBJ = $(SHARED_SRC:.c=.o)
+
+# On MSYS2, we need to build tree-sitter from source (package only has CLI, no library)
+ifneq ($(IS_MSYS),)
+    TREE_SITTER_LIB_OBJ = tree-sitter/lib/src/lib.o
+else
+    TREE_SITTER_LIB_OBJ =
+endif
 
 # TypeScript language files
 TS_TREE_SITTER_SRC = $(TS_GRAMMAR_DIR)/src/parser.c $(TS_GRAMMAR_DIR)/src/scanner.c
@@ -401,27 +443,27 @@ $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
 # TypeScript indexer
-$(BUILD_DIR)/index-ts: $(SHARED_OBJ) $(TS_TREE_SITTER_OBJ) $(TS_LANGUAGE_OBJ) $(TS_MAIN_OBJ)
+$(BUILD_DIR)/index-ts: $(SHARED_OBJ) $(TREE_SITTER_LIB_OBJ) $(TS_TREE_SITTER_OBJ) $(TS_LANGUAGE_OBJ) $(TS_MAIN_OBJ)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 # C indexer
-$(BUILD_DIR)/index-c: $(SHARED_OBJ) $(C_TREE_SITTER_OBJ) $(C_LANGUAGE_OBJ) $(C_MAIN_OBJ)
+$(BUILD_DIR)/index-c: $(SHARED_OBJ) $(TREE_SITTER_LIB_OBJ) $(C_TREE_SITTER_OBJ) $(C_LANGUAGE_OBJ) $(C_MAIN_OBJ)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 # PHP indexer
-$(BUILD_DIR)/index-php: $(SHARED_OBJ) $(PHP_TREE_SITTER_OBJ) $(PHP_LANGUAGE_OBJ) $(PHP_MAIN_OBJ)
+$(BUILD_DIR)/index-php: $(SHARED_OBJ) $(TREE_SITTER_LIB_OBJ) $(PHP_TREE_SITTER_OBJ) $(PHP_LANGUAGE_OBJ) $(PHP_MAIN_OBJ)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 # Go indexer
-$(BUILD_DIR)/index-go: $(SHARED_OBJ) $(GO_TREE_SITTER_OBJ) $(GO_LANGUAGE_OBJ) $(GO_MAIN_OBJ)
+$(BUILD_DIR)/index-go: $(SHARED_OBJ) $(TREE_SITTER_LIB_OBJ) $(GO_TREE_SITTER_OBJ) $(GO_LANGUAGE_OBJ) $(GO_MAIN_OBJ)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 # Python indexer
-$(BUILD_DIR)/index-python: $(SHARED_OBJ) $(PYTHON_TREE_SITTER_OBJ) $(PYTHON_LANGUAGE_OBJ) $(PYTHON_MAIN_OBJ)
+$(BUILD_DIR)/index-python: $(SHARED_OBJ) $(TREE_SITTER_LIB_OBJ) $(PYTHON_TREE_SITTER_OBJ) $(PYTHON_LANGUAGE_OBJ) $(PYTHON_MAIN_OBJ)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 # Query tool
-$(BUILD_DIR)/qi: $(SHARED_OBJ) $(QUERY_OBJ)
+$(BUILD_DIR)/qi: $(SHARED_OBJ) $(TREE_SITTER_LIB_OBJ) $(QUERY_OBJ)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 # Convenience symlinks in root
@@ -442,6 +484,12 @@ $(BUILD_DIR)/qi: $(SHARED_OBJ) $(QUERY_OBJ)
 
 ./qi: $(BUILD_DIR)/qi
 	ln -sf $(BUILD_DIR)/qi qi
+
+# Build tree-sitter library from source (MSYS2 only - package doesn't include library)
+ifneq ($(IS_MSYS),)
+tree-sitter/lib/src/lib.o: tree-sitter/lib/src/lib.c
+	$(CC) $(THIRD_PARTY_CFLAGS) -c $< -o $@
+endif
 
 # Pattern rules for object files
 # Third-party tree-sitter parser code (relaxed warnings)
@@ -465,7 +513,7 @@ $(PYTHON_GRAMMAR_DIR)/src/%.o: $(PYTHON_GRAMMAR_DIR)/src/%.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -f $(SHARED_OBJ) $(TS_TREE_SITTER_OBJ) $(TS_LANGUAGE_OBJ) $(TS_MAIN_OBJ) $(C_TREE_SITTER_OBJ) $(C_LANGUAGE_OBJ) $(C_MAIN_OBJ) $(PHP_TREE_SITTER_OBJ) $(PHP_LANGUAGE_OBJ) $(PHP_MAIN_OBJ) $(GO_TREE_SITTER_OBJ) $(GO_LANGUAGE_OBJ) $(GO_MAIN_OBJ) $(PYTHON_TREE_SITTER_OBJ) $(PYTHON_LANGUAGE_OBJ) $(PYTHON_MAIN_OBJ) $(QUERY_OBJ)
+	rm -f $(SHARED_OBJ) $(TREE_SITTER_LIB_OBJ) $(TS_TREE_SITTER_OBJ) $(TS_LANGUAGE_OBJ) $(TS_MAIN_OBJ) $(C_TREE_SITTER_OBJ) $(C_LANGUAGE_OBJ) $(C_MAIN_OBJ) $(PHP_TREE_SITTER_OBJ) $(PHP_LANGUAGE_OBJ) $(PHP_MAIN_OBJ) $(GO_TREE_SITTER_OBJ) $(GO_LANGUAGE_OBJ) $(GO_MAIN_OBJ) $(PYTHON_TREE_SITTER_OBJ) $(PYTHON_LANGUAGE_OBJ) $(PYTHON_MAIN_OBJ) $(QUERY_OBJ)
 	rm -rf $(BUILD_DIR)
 	rm -f index-ts index-c index-php index-go index-python qi
 

--- a/go/go_language.c
+++ b/go/go_language.c
@@ -2686,8 +2686,8 @@ void parser_free(GoParser *parser) {
 
 int parser_parse_file(GoParser *parser, const char *filepath,
                       const char *project_root, ParseResult *result) {
-    /* Open file */
-    FILE *file = safe_fopen(filepath, "r", 0);
+    /* Open file in binary mode for accurate byte count */
+    FILE *file = safe_fopen(filepath, "rb", 0);
     if (!file) {
         fprintf(stderr, "Failed to open file: %s\n", filepath);
         return -1;

--- a/php/php_language.c
+++ b/php/php_language.c
@@ -2041,7 +2041,7 @@ int parser_init(PHPParser *parser, SymbolFilter *filter) {
 }
 
 int parser_parse_file(PHPParser *parser, const char *filepath, const char *project_root, ParseResult *result) {
-    FILE *fp = safe_fopen(filepath, "r", 0);
+    FILE *fp = safe_fopen(filepath, "rb", 0);  /* binary mode for accurate byte count */
     if (!fp) {
         fprintf(stderr, "Cannot open file: %s\n", filepath);
         return -1;

--- a/python/python_language.c
+++ b/python/python_language.c
@@ -1654,7 +1654,7 @@ void parser_set_debug(PythonParser *parser, int debug) {
 
 /* Parse a Python file */
 int parser_parse_file(PythonParser *parser, const char *filepath, const char *project_root, ParseResult *result) {
-    FILE *fp = safe_fopen(filepath, "r", 0);
+    FILE *fp = safe_fopen(filepath, "rb", 0);  /* binary mode for accurate byte count */
     if (!fp) {
         fprintf(stderr, "Cannot open file: %s\n", filepath);
         return -1;

--- a/query-index.c
+++ b/query-index.c
@@ -19,12 +19,31 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <ctype.h>
-#include <regex.h>
 #include <errno.h>
 #include <limits.h>
 #include <sys/stat.h>
+
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
+/* Windows/MinGW: provide POSIX compatibility */
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+
+/* strndup is not available on Windows */
+static char *strndup(const char *s, size_t n) {
+    size_t len = strnlen(s, n);
+    char *new_str = malloc(len + 1);
+    if (new_str) {
+        memcpy(new_str, s, len);
+        new_str[len] = '\0';
+    }
+    return new_str;
+}
+#else
+#include <strings.h>
+#endif
+
+#include <regex.h>
 #include "shared/database.h"
 #include "shared/constants.h"
 #include "shared/file_opener.h"

--- a/shared/file_opener.c
+++ b/shared/file_opener.c
@@ -1,18 +1,18 @@
 /* SourceMinder
- * Copyright 2025 Eli Bird 
- * 
+ * Copyright 2025 Eli Bird
+ *
  * This file is part of SourceMinder.
- * 
- * SourceMinder is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
+ *
+ * SourceMinder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  *  your option) any later version.
  *
- * SourceMinder is distributed in the hope that it will be useful, but 
- * WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+ * SourceMinder is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * You should have received a copy of the GNU General Public License 
+ * You should have received a copy of the GNU General Public License
  * along with SourceMinder. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "file_opener.h"
@@ -24,9 +24,15 @@ FILE *safe_fopen(const char *filepath, const char *mode, int silent) {
         return NULL;
     }
 
-    /* Use lstat to avoid following symlinks */
+    /* Use lstat to avoid following symlinks (stat on Windows where lstat isn't available) */
     struct stat st;
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
+    /* Windows: use stat (symlinks are less common and handled differently) */
+    if (stat(filepath, &st) != 0) {
+#else
+    /* Unix: use lstat to not follow symlinks */
     if (lstat(filepath, &st) != 0) {
+#endif
         /* File doesn't exist or can't be accessed - this is normal, return NULL silently */
         return NULL;
     }

--- a/shared/file_walker.c
+++ b/shared/file_walker.c
@@ -1,23 +1,22 @@
 /* SourceMinder
- * Copyright 2025 Eli Bird 
- * 
+ * Copyright 2025 Eli Bird
+ *
  * This file is part of SourceMinder.
- * 
- * SourceMinder is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
+ *
+ * SourceMinder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  *  your option) any later version.
  *
- * SourceMinder is distributed in the hope that it will be useful, but 
- * WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+ * SourceMinder is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * You should have received a copy of the GNU General Public License 
+ * You should have received a copy of the GNU General Public License
  * along with SourceMinder. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "file_walker.h"
 #include "string_utils.h"
-#include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
@@ -25,7 +24,77 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
+/* Windows/MinGW: provide fnmatch compatibility */
+#include <io.h>
+#define FNM_PATHNAME 1
+#define FNM_NOMATCH 1
+
+/* Simple fnmatch implementation for Windows */
+static int fnmatch(const char *pattern, const char *string, int flags) {
+    const char *p = pattern;
+    const char *s = string;
+
+    while (*p && *s) {
+        if (*p == '*') {
+            /* Skip consecutive asterisks */
+            while (*p == '*') p++;
+            if (*p == '\0') return 0;  /* Trailing * matches everything */
+
+            /* Try matching the rest of the pattern */
+            while (*s) {
+                if (fnmatch(p, s, flags) == 0) return 0;
+                /* If FNM_PATHNAME is set, don't match past '/' */
+                if ((flags & FNM_PATHNAME) && *s == '/') break;
+                s++;
+            }
+            return FNM_NOMATCH;
+        } else if (*p == '?') {
+            /* Match any single character (except '/' if FNM_PATHNAME) */
+            if ((flags & FNM_PATHNAME) && *s == '/') return FNM_NOMATCH;
+            p++;
+            s++;
+        } else if (*p == '[') {
+            /* Character class - simplified implementation */
+            int inverted = 0;
+            int matched = 0;
+            p++;
+            if (*p == '!' || *p == '^') {
+                inverted = 1;
+                p++;
+            }
+            while (*p && *p != ']') {
+                if (p[1] == '-' && p[2] && p[2] != ']') {
+                    /* Range */
+                    if (*s >= *p && *s <= p[2]) matched = 1;
+                    p += 3;
+                } else {
+                    if (*s == *p) matched = 1;
+                    p++;
+                }
+            }
+            if (*p == ']') p++;
+            if (inverted) matched = !matched;
+            if (!matched) return FNM_NOMATCH;
+            s++;
+        } else {
+            /* Literal character match */
+            if (*p != *s) return FNM_NOMATCH;
+            p++;
+            s++;
+        }
+    }
+
+    /* Handle trailing asterisks */
+    while (*p == '*') p++;
+
+    return (*p == '\0' && *s == '\0') ? 0 : FNM_NOMATCH;
+}
+#else
+#include <unistd.h>
 #include <fnmatch.h>
+#endif
 
 /* FileList growth constants */
 #define FILE_LIST_INITIAL_CAPACITY 32

--- a/shared/file_watcher.c
+++ b/shared/file_watcher.c
@@ -1,18 +1,18 @@
 /* SourceMinder
- * Copyright 2025 Eli Bird 
- * 
+ * Copyright 2025 Eli Bird
+ *
  * This file is part of SourceMinder.
- * 
- * SourceMinder is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
+ *
+ * SourceMinder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  *  your option) any later version.
  *
- * SourceMinder is distributed in the hope that it will be useful, but 
- * WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+ * SourceMinder is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * You should have received a copy of the GNU General Public License 
+ * You should have received a copy of the GNU General Public License
  * along with SourceMinder. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "file_watcher.h"
@@ -20,14 +20,312 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
-#include <dirent.h>
 #include <errno.h>
 #include <time.h>
+
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
+/* ============================================================================
+ * Windows implementation using ReadDirectoryChangesW
+ * ============================================================================ */
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <dirent.h>
 #include <sys/stat.h>
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
-/* BSD kqueue implementation (macOS, FreeBSD, OpenBSD, NetBSD, DragonFly BSD) */
+/* Directory watch handle */
+typedef struct {
+    HANDLE hDir;           /* Directory handle */
+    char path[4096];       /* Directory path */
+    OVERLAPPED overlapped; /* Overlapped I/O structure */
+    char buffer[8192];     /* Buffer for change notifications */
+} DirWatch;
+
+/* File watcher structure for Windows */
+struct FileWatcher {
+    DirWatch *watches;                         /* Array of directory watches */
+    int watch_count;                           /* Number of watches */
+    int watch_capacity;                        /* Capacity of watches array */
+    char extensions[MAX_FILE_EXTENSIONS][FILE_EXTENSION_MAX_LENGTH];  /* File extensions */
+    int extension_count;                       /* Number of extensions */
+};
+
+/* Check if filename has valid extension */
+static int has_valid_extension_array(const char *filename, char extensions[][FILE_EXTENSION_MAX_LENGTH], int count) {
+    if (!filename) return 0;
+
+    const char *dot = strrchr(filename, '.');
+    if (!dot) return 0;
+
+    for (int i = 0; i < count; i++) {
+        if (_stricmp(dot, extensions[i]) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Get current time in milliseconds */
+static long long current_time_ms(void) {
+    LARGE_INTEGER freq, counter;
+    QueryPerformanceFrequency(&freq);
+    QueryPerformanceCounter(&counter);
+    return (long long)(counter.QuadPart * 1000 / freq.QuadPart);
+}
+
+/* Add watch for a single directory */
+static int add_watch(FileWatcher *watcher, const char *path) {
+    /* Expand array if needed */
+    if (watcher->watch_count >= watcher->watch_capacity) {
+        int new_capacity = watcher->watch_capacity == 0 ? 16 : watcher->watch_capacity * 2;
+        DirWatch *new_watches = realloc(watcher->watches, (size_t)new_capacity * sizeof(DirWatch));
+        if (!new_watches) {
+            fprintf(stderr, "Error: Failed to expand watch array\n");
+            return -1;
+        }
+        watcher->watches = new_watches;
+        watcher->watch_capacity = new_capacity;
+    }
+
+    /* Open directory handle for monitoring */
+    HANDLE hDir = CreateFileA(
+        path,
+        FILE_LIST_DIRECTORY,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        NULL,
+        OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
+        NULL
+    );
+
+    if (hDir == INVALID_HANDLE_VALUE) {
+        /* Silently skip directories we can't watch */
+        return 0;
+    }
+
+    DirWatch *watch = &watcher->watches[watcher->watch_count];
+    watch->hDir = hDir;
+    strncpy(watch->path, path, sizeof(watch->path) - 1);
+    watch->path[sizeof(watch->path) - 1] = '\0';
+    memset(&watch->overlapped, 0, sizeof(watch->overlapped));
+    watch->overlapped.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+
+    /* Start watching */
+    BOOL success = ReadDirectoryChangesW(
+        hDir,
+        watch->buffer,
+        sizeof(watch->buffer),
+        FALSE,  /* Don't watch subtree - we add each dir separately */
+        FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_SIZE,
+        NULL,
+        &watch->overlapped,
+        NULL
+    );
+
+    if (!success) {
+        CloseHandle(watch->overlapped.hEvent);
+        CloseHandle(hDir);
+        return 0;
+    }
+
+    watcher->watch_count++;
+    return 0;
+}
+
+/* Recursively add watches for directory and subdirectories */
+static int add_watch_recursive(FileWatcher *watcher, const char *directory) {
+    /* Add watch for this directory */
+    if (add_watch(watcher, directory) != 0) {
+        return -1;
+    }
+
+    /* Recursively add subdirectories */
+    DIR *dir = opendir(directory);
+    if (!dir) return 0;
+
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+
+        char path[4096];
+        snprintf(path, sizeof(path), "%s/%s", directory, entry->d_name);
+
+        struct stat st;
+        if (stat(path, &st) == 0 && S_ISDIR(st.st_mode)) {
+            add_watch_recursive(watcher, path);
+        }
+    }
+
+    closedir(dir);
+    return 0;
+}
+
+FileWatcher* file_watcher_init(void) {
+    FileWatcher *watcher = calloc(1, sizeof(FileWatcher));
+    if (!watcher) {
+        fprintf(stderr, "Error: Failed to allocate file watcher\n");
+        return NULL;
+    }
+    return watcher;
+}
+
+int file_watcher_add_directory(FileWatcher *watcher, const char *directory,
+                                const char **extensions, int extension_count) {
+    if (!watcher || !directory) return -1;
+
+    /* Copy extensions */
+    watcher->extension_count = extension_count < MAX_FILE_EXTENSIONS ? extension_count : MAX_FILE_EXTENSIONS;
+    for (int i = 0; i < watcher->extension_count; i++) {
+        if (extensions[i]) {
+            snprintf(watcher->extensions[i], FILE_EXTENSION_MAX_LENGTH, "%s", extensions[i]);
+        } else {
+            watcher->extensions[i][0] = '\0';
+        }
+    }
+
+    return add_watch_recursive(watcher, directory);
+}
+
+int file_watcher_wait(FileWatcher *watcher, FileEvent *events, int max_events) {
+    if (!watcher || !events || watcher->watch_count == 0) return -1;
+
+    int event_count = 0;
+    long long last_event_time = 0;
+
+    /* Build array of event handles */
+    HANDLE *handles = malloc((size_t)watcher->watch_count * sizeof(HANDLE));
+    if (!handles) return -1;
+
+    for (int i = 0; i < watcher->watch_count; i++) {
+        handles[i] = watcher->watches[i].overlapped.hEvent;
+    }
+
+    while (1) {
+        /* Calculate timeout */
+        DWORD timeout_ms;
+        if (last_event_time > 0) {
+            long long elapsed = current_time_ms() - last_event_time;
+            if (elapsed >= DEBOUNCE_MS) {
+                break;
+            }
+            timeout_ms = (DWORD)(DEBOUNCE_MS - elapsed);
+        } else {
+            timeout_ms = INFINITE;
+        }
+
+        /* Wait for any directory change */
+        DWORD result = WaitForMultipleObjects((DWORD)watcher->watch_count, handles, FALSE, timeout_ms);
+
+        if (result == WAIT_TIMEOUT) {
+            break;  /* Debounce complete */
+        }
+
+        if (result == WAIT_FAILED) {
+            free(handles);
+            return -1;
+        }
+
+        if (result >= WAIT_OBJECT_0 && result < WAIT_OBJECT_0 + (DWORD)watcher->watch_count) {
+            int idx = (int)(result - WAIT_OBJECT_0);
+            DirWatch *watch = &watcher->watches[idx];
+
+            /* Get the result */
+            DWORD bytes_returned;
+            if (GetOverlappedResult(watch->hDir, &watch->overlapped, &bytes_returned, FALSE)) {
+                /* Process notifications */
+                FILE_NOTIFY_INFORMATION *notify = (FILE_NOTIFY_INFORMATION *)watch->buffer;
+
+                while (1) {
+                    /* Convert wide filename to UTF-8 */
+                    char filename[512];
+                    int len = WideCharToMultiByte(CP_UTF8, 0,
+                        notify->FileName, (int)(notify->FileNameLength / sizeof(WCHAR)),
+                        filename, sizeof(filename) - 1, NULL, NULL);
+                    filename[len] = '\0';
+
+                    /* Check extension */
+                    if (has_valid_extension_array(filename, watcher->extensions, watcher->extension_count)) {
+                        /* Build full path */
+                        char filepath[4096];
+                        snprintf(filepath, sizeof(filepath), "%s/%s", watch->path, filename);
+
+                        /* Check for duplicates */
+                        int already_exists = 0;
+                        for (int i = 0; i < event_count; i++) {
+                            if (strcmp(events[i].filepath, filepath) == 0) {
+                                already_exists = 1;
+                                break;
+                            }
+                        }
+
+                        if (!already_exists && event_count < max_events) {
+                            strncpy(events[event_count].filepath, filepath, sizeof(events[0].filepath) - 1);
+                            events[event_count].filepath[sizeof(events[0].filepath) - 1] = '\0';
+
+                            switch (notify->Action) {
+                                case FILE_ACTION_ADDED:
+                                case FILE_ACTION_RENAMED_NEW_NAME:
+                                    events[event_count].type = FILE_EVENT_CREATED;
+                                    break;
+                                case FILE_ACTION_REMOVED:
+                                case FILE_ACTION_RENAMED_OLD_NAME:
+                                    events[event_count].type = FILE_EVENT_DELETED;
+                                    break;
+                                default:
+                                    events[event_count].type = FILE_EVENT_MODIFIED;
+                                    break;
+                            }
+
+                            event_count++;
+                            last_event_time = current_time_ms();
+                        }
+                    }
+
+                    if (notify->NextEntryOffset == 0) break;
+                    notify = (FILE_NOTIFY_INFORMATION *)((char *)notify + notify->NextEntryOffset);
+                }
+            }
+
+            /* Reset the event and start watching again */
+            ResetEvent(watch->overlapped.hEvent);
+            ReadDirectoryChangesW(
+                watch->hDir,
+                watch->buffer,
+                sizeof(watch->buffer),
+                FALSE,
+                FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_SIZE,
+                NULL,
+                &watch->overlapped,
+                NULL
+            );
+        }
+    }
+
+    free(handles);
+    return event_count;
+}
+
+void file_watcher_free(FileWatcher *watcher) {
+    if (!watcher) return;
+
+    for (int i = 0; i < watcher->watch_count; i++) {
+        CancelIo(watcher->watches[i].hDir);
+        CloseHandle(watcher->watches[i].overlapped.hEvent);
+        CloseHandle(watcher->watches[i].hDir);
+    }
+
+    free(watcher->watches);
+    free(watcher);
+}
+
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+/* ============================================================================
+ * BSD kqueue implementation (macOS, FreeBSD, OpenBSD, NetBSD, DragonFly BSD)
+ * ============================================================================ */
+#include <unistd.h>
+#include <dirent.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/event.h>
 #include <sys/time.h>
@@ -295,7 +593,12 @@ void file_watcher_free(FileWatcher *watcher) {
 }
 
 #else
-/* Linux inotify implementation */
+/* ============================================================================
+ * Linux inotify implementation
+ * ============================================================================ */
+#include <unistd.h>
+#include <dirent.h>
+#include <sys/stat.h>
 #include <sys/inotify.h>
 #include <sys/select.h>
 

--- a/shared/paths.c
+++ b/shared/paths.c
@@ -1,18 +1,18 @@
 /* SourceMinder
- * Copyright 2025 Eli Bird 
- * 
+ * Copyright 2025 Eli Bird
+ *
  * This file is part of SourceMinder.
- * 
- * SourceMinder is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
+ *
+ * SourceMinder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  *  your option) any later version.
  *
- * SourceMinder is distributed in the hope that it will be useful, but 
- * WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+ * SourceMinder is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * You should have received a copy of the GNU General Public License 
+ * You should have received a copy of the GNU General Public License
  * along with SourceMinder. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "paths.h"
@@ -20,7 +20,38 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
+#include <io.h>
+#include <windows.h>
+#define access _access
+#define F_OK 0
+
+/* Get directory containing the current executable */
+static int get_executable_dir(char *out_path, size_t out_size) {
+    char exe_path[MAX_PATH];
+    DWORD len = GetModuleFileNameA(NULL, exe_path, MAX_PATH);
+    if (len == 0 || len >= MAX_PATH) {
+        return -1;
+    }
+    /* Find last backslash or forward slash and truncate */
+    char *last_sep = strrchr(exe_path, '\\');
+    char *last_fwd = strrchr(exe_path, '/');
+    if (last_fwd && (!last_sep || last_fwd > last_sep)) {
+        last_sep = last_fwd;
+    }
+    if (last_sep) {
+        *last_sep = '\0';
+    }
+    if (strlen(exe_path) >= out_size) {
+        return -1;
+    }
+    strcpy(out_path, exe_path);
+    return 0;
+}
+#else
 #include <unistd.h>
+#endif
 
 /* Check if a directory exists */
 static int dir_exists(const char *path) {
@@ -59,7 +90,35 @@ int resolve_lang_data_dir(const char *lang, char *out_path, size_t out_size) {
     }
 
     /* 3. Check platform-specific installation directories */
-#ifdef __APPLE__
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
+    /* Windows: First check relative to executable (works outside MSYS2) */
+    char exe_dir[PATH_MAX_LENGTH];
+    if (get_executable_dir(exe_dir, sizeof(exe_dir)) == 0) {
+        /* Check exe_dir/../<lang>/data (typical layout) */
+        snprintf(candidate, sizeof(candidate), "%s/../%s/data", exe_dir, lang);
+        if (dir_exists(candidate)) {
+            snprintf(out_path, out_size, "%s", candidate);
+            return 0;
+        }
+        /* Check exe_dir/<lang>/data */
+        snprintf(candidate, sizeof(candidate), "%s/%s/data", exe_dir, lang);
+        if (dir_exists(candidate)) {
+            snprintf(out_path, out_size, "%s", candidate);
+            return 0;
+        }
+    }
+    /* MSYS2: Check MSYS2 virtual paths (only work inside MSYS2 shell) */
+    snprintf(candidate, sizeof(candidate), "/ucrt64/share/sourceminder/%s/data", lang);
+    if (dir_exists(candidate)) {
+        snprintf(out_path, out_size, "%s", candidate);
+        return 0;
+    }
+    snprintf(candidate, sizeof(candidate), "/mingw64/share/sourceminder/%s/data", lang);
+    if (dir_exists(candidate)) {
+        snprintf(out_path, out_size, "%s", candidate);
+        return 0;
+    }
+#elif defined(__APPLE__)
     /* macOS: /usr/local/share/indexer-c/<lang>/data */
     snprintf(candidate, sizeof(candidate), "/usr/local/share/indexer-c/%s/data", lang);
     if (dir_exists(candidate)) {
@@ -104,7 +163,35 @@ int resolve_shared_data_dir(char *out_path, size_t out_size) {
     }
 
     /* 3. Check platform-specific installation directories */
-#ifdef __APPLE__
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
+    /* Windows: First check relative to executable (works outside MSYS2) */
+    char exe_dir[PATH_MAX_LENGTH];
+    if (get_executable_dir(exe_dir, sizeof(exe_dir)) == 0) {
+        /* Check exe_dir/../shared/data (typical layout) */
+        snprintf(candidate, sizeof(candidate), "%s/../shared/data", exe_dir);
+        if (dir_exists(candidate)) {
+            snprintf(out_path, out_size, "%s", candidate);
+            return 0;
+        }
+        /* Check exe_dir/shared/data */
+        snprintf(candidate, sizeof(candidate), "%s/shared/data", exe_dir);
+        if (dir_exists(candidate)) {
+            snprintf(out_path, out_size, "%s", candidate);
+            return 0;
+        }
+    }
+    /* MSYS2: Check MSYS2 virtual paths (only work inside MSYS2 shell) */
+    snprintf(candidate, sizeof(candidate), "/ucrt64/share/sourceminder/shared/data");
+    if (dir_exists(candidate)) {
+        snprintf(out_path, out_size, "%s", candidate);
+        return 0;
+    }
+    snprintf(candidate, sizeof(candidate), "/mingw64/share/sourceminder/shared/data");
+    if (dir_exists(candidate)) {
+        snprintf(out_path, out_size, "%s", candidate);
+        return 0;
+    }
+#elif defined(__APPLE__)
     /* macOS: /usr/local/share/indexer-c/shared/data */
     snprintf(candidate, sizeof(candidate), "/usr/local/share/indexer-c/shared/data");
     if (dir_exists(candidate)) {
@@ -149,7 +236,35 @@ int resolve_data_file(const char *relative_path, char *out_path, size_t out_size
     }
 
     /* 3. Check platform-specific installation directories */
-#ifdef __APPLE__
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
+    /* Windows: First check relative to executable (works outside MSYS2) */
+    char exe_dir[PATH_MAX_LENGTH];
+    if (get_executable_dir(exe_dir, sizeof(exe_dir)) == 0) {
+        /* Check exe_dir/../<relative_path> (typical layout) */
+        snprintf(candidate, sizeof(candidate), "%s/../%s", exe_dir, relative_path);
+        if (file_exists(candidate)) {
+            snprintf(out_path, out_size, "%s", candidate);
+            return 0;
+        }
+        /* Check exe_dir/<relative_path> */
+        snprintf(candidate, sizeof(candidate), "%s/%s", exe_dir, relative_path);
+        if (file_exists(candidate)) {
+            snprintf(out_path, out_size, "%s", candidate);
+            return 0;
+        }
+    }
+    /* MSYS2: Check MSYS2 virtual paths (only work inside MSYS2 shell) */
+    snprintf(candidate, sizeof(candidate), "/ucrt64/share/sourceminder/%s", relative_path);
+    if (file_exists(candidate)) {
+        snprintf(out_path, out_size, "%s", candidate);
+        return 0;
+    }
+    snprintf(candidate, sizeof(candidate), "/mingw64/share/sourceminder/%s", relative_path);
+    if (file_exists(candidate)) {
+        snprintf(out_path, out_size, "%s", candidate);
+        return 0;
+    }
+#elif defined(__APPLE__)
     /* macOS: /usr/local/share/indexer-c/<relative_path> */
     snprintf(candidate, sizeof(candidate), "/usr/local/share/indexer-c/%s", relative_path);
     if (file_exists(candidate)) {

--- a/shared/string_utils.c
+++ b/shared/string_utils.c
@@ -1,18 +1,18 @@
 /* SourceMinder
- * Copyright 2025 Eli Bird 
- * 
+ * Copyright 2025 Eli Bird
+ *
  * This file is part of SourceMinder.
- * 
- * SourceMinder is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
+ *
+ * SourceMinder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  *  your option) any later version.
  *
- * SourceMinder is distributed in the hope that it will be useful, but 
- * WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+ * SourceMinder is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * You should have received a copy of the GNU General Public License 
+ * You should have received a copy of the GNU General Public License
  * along with SourceMinder. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "string_utils.h"
@@ -20,8 +20,15 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
+/* Windows: backtrace not available */
+#define HAS_BACKTRACE 0
+#else
 #include <execinfo.h>  /* For backtrace() */
 #include <unistd.h>    /* For readlink() */
+#define HAS_BACKTRACE 1
+#endif
 
 size_t strnlength(const char *s, size_t n)
 {
@@ -78,6 +85,7 @@ void safe_extract_node_text(const char *source_code, TSNode node, char *buffer,
         fprintf(stderr, "If this seems like a bug, the extraction logic may need fixing.\n");
 
         /* Print stack trace to help identify the caller */
+#if HAS_BACKTRACE
         fprintf(stderr, "\nStack trace:\n");
         void *stack_frames[20];
         int frame_count = backtrace(stack_frames, 20);
@@ -136,6 +144,9 @@ void safe_extract_node_text(const char *source_code, TSNode node, char *buffer,
         } else {
             fprintf(stderr, "  (backtrace_symbols failed)\n");
         }
+#else
+        fprintf(stderr, "\n(Stack trace not available on Windows)\n");
+#endif
 
         fprintf(stderr, "======================================\n");
         exit(1);

--- a/typescript/ts_language.c
+++ b/typescript/ts_language.c
@@ -2209,7 +2209,7 @@ int parser_init(TypeScriptParser *parser, SymbolFilter *filter) {
 int parser_parse_file(TypeScriptParser *parser, const char *filepath, const char *project_root, ParseResult *result) {
     if (g_debug) fprintf(stderr, "[DEBUG] parser_parse_file: Starting to parse %s (g_debug=%d)\n", filepath, g_debug);
 
-    FILE *fp = safe_fopen(filepath, "r", 0);
+    FILE *fp = safe_fopen(filepath, "rb", 0);  /* binary mode for accurate byte count */
     if (!fp) {
         fprintf(stderr, "Cannot open file: %s\n", filepath);
         return -1;


### PR DESCRIPTION
## Summary
- Add support for building and running SourceMinder on Windows using MSYS2 (MinGW UCRT64)
- Fix CRLF file reading issue that affects all platforms with Windows line endings

## Changes

### Build system (configure)
- Detect MSYS2/MinGW environment and set appropriate paths
- Build tree-sitter from source (MSYS2 package only includes CLI, not the library)
- Link against libsystre for POSIX regex support
- Add .exe extension for Windows executables

### Platform compatibility
- `shared/file_watcher.c`: Windows implementation using ReadDirectoryChangesW API
- `shared/file_walker.c`: Add fnmatch() implementation for Windows
- `shared/file_opener.c`: Use stat() instead of lstat() on Windows
- `shared/string_utils.c`: Conditional backtrace support (not available on Windows)
- `shared/paths.c`: Resolve paths relative to executable for running outside MSYS2 shell
- `query-index.c`: Add strndup() and strcasecmp/strncasecmp for Windows

### Bug fix (all platforms)
- Use binary mode ("rb") when reading source files to fix CRLF handling on Windows
- This change is safe on Unix where binary/text modes are identical

### Documentation
- Add MSYS2_SETUP.md with build instructions for Windows

## Test plan
- [x] Tested on Windows 11 with MSYS2 UCRT64
- [x] index-python successfully indexes Python files
- [x] qi query tool works correctly
- [x] Files with CRLF line endings are handled correctly
- [x] Mac/Linux builds should be unaffected (conditional compilation)

🤖 Generated with [Claude Code](https://claude.ai/code)